### PR TITLE
pass optional paths for trained models to the reader allowing for using ...

### DIFF
--- a/bin/nlpnet-test.py
+++ b/bin/nlpnet-test.py
@@ -224,7 +224,7 @@ def evaluate_srl_classify(no_repeat=False, gold_file=None):
     md = Metadata.load_from_file('srl_classify')
     nn = taggers.load_network(md)
     r = taggers.create_reader(md, gold_file)
-    r.create_converter(md)
+    r.create_converter()
     
     r.codify_sentences()
     hits = 0

--- a/bin/nlpnet-train.py
+++ b/bin/nlpnet-train.py
@@ -27,16 +27,16 @@ from nlpnet.network import Network, ConvolutionalNetwork
 ### FUNCTION DEFINITIONS ###
 ############################
 
-def create_reader(args):
+def create_reader(args, md):
     """
     Creates and returns a TextReader object according to the task at hand.
     """
     logger.info("Reading text...")
     if args.task == 'pos':
-        text_reader = pos.pos_reader.POSReader(filename=args.gold)
+        text_reader = pos.pos_reader.POSReader(md, filename=args.gold)
     
     elif args.task.startswith('srl'):
-        text_reader = srl.srl_reader.SRLReader(filename=args.gold, only_boundaries=args.identify, 
+        text_reader = srl.srl_reader.SRLReader(md, filename=args.gold, only_boundaries=args.identify, 
                                                only_classify=args.classify,
                                                only_predicates=args.predicates)
     
@@ -185,7 +185,6 @@ if __name__ == '__main__':
     logger = logging.getLogger("Logger")
 
     config.set_data_dir(args.data)
-    text_reader = create_reader(args)
     
     use_caps = args.caps is not None
     use_suffix = args.suffix is not None
@@ -196,13 +195,14 @@ if __name__ == '__main__':
     
     if not args.load_network:
         # if we are about to create a new network, create the metadata too
-        md = metadata.Metadata(args.task, use_caps, use_suffix, use_prefix, 
+        md = metadata.Metadata(args.task, None, use_caps, use_suffix, use_prefix, 
                                use_pos, use_chunk, use_lemma)
         md.save_to_file()
     else:
         md = metadata.Metadata.load_from_file(args.task)
-    
-    text_reader.create_converter(md)
+        
+    text_reader = create_reader(args, md)
+    text_reader.create_converter()
     text_reader.codify_sentences()
     
     if args.load_network or args.semi:

--- a/nlpnet/attributes.py
+++ b/nlpnet/attributes.py
@@ -3,7 +3,6 @@
 import logging
 import numpy as np
 
-import config
 from word_dictionary import WordDictionary as WD
 from collections import defaultdict
 
@@ -46,22 +45,22 @@ class Affix(object):
     num_prefixes_per_size = {}
     
     @classmethod
-    def load_suffixes(cls):
+    def load_suffixes(cls, md):
         """
         Loads suffixes from the suffix file.
         """
-        cls.load_affixes(cls.suffix_codes, config.FILES['suffixes'])
+        cls.load_affixes(cls.suffix_codes, md.paths['suffixes'])
         
         # +1 because of the unkown suffix code
         cls.num_suffixes_per_size = {size: len(cls.suffix_codes[size]) + 1
                                      for size in cls.suffix_codes}
     
     @classmethod
-    def load_prefixes(cls):
+    def load_prefixes(cls, md):
         """
         Loads prefixes from the prefix file.
         """
-        cls.load_affixes(cls.prefix_codes, config.FILES['prefixes'])
+        cls.load_affixes(cls.prefix_codes, md.paths['prefixes'])
         
         # +1 because of the unkown prefix code
         cls.num_prefixes_per_size = {size: len(cls.prefix_codes[size]) + 1

--- a/nlpnet/config.py
+++ b/nlpnet/config.py
@@ -9,68 +9,73 @@ import os
 data_dir = None
 FILES = {}
 
-def set_data_dir(directory):
+def get_config_paths(directory):
     """Sets the data directory containing the data for the models."""
     assert os.path.isdir(directory), 'Invalid data directory'
-    
+
+    return { key: os.path.join(directory, value) for key, value in [ 
+        # cross-task data
+        ('.', '.'), #for data_dir access
+        ('vocabulary'                  , 'vocabulary.txt'),
+        ('word_dict_dat'               , 'vocabulary.txt'), # deprecated
+        ('type_features'               , 'types-features.npy'),
+        ('termvectors'                 , 'termvectors.txt'),
+
+        # POS
+        ('network_pos'                 , 'pos-network.npz'),
+        ('pos_tags'                    , 'pos-tags.txt'),
+        ('pos_tag_dict'                , 'pos-tags.txt'),
+        ('suffixes'                    , 'suffixes.txt'),
+        ('prefixes'                    , 'prefixes.txt'),
+        ('metadata_pos'                , 'metadata-pos.pickle'),
+        ('type_features_pos'           , 'types-features-pos.npy'),
+        ('caps_features_pos'           , 'caps-features-pos.npy'),
+        ('suffix_features_pos'         , 'suffix-features-pos.npy'),
+        ('prefix_features_pos'         , 'prefix-features-pos.npy'),
+
+        # chunk
+        ('chunk_tag_dict'              , 'chunk-tag-dict.pickle'),
+        ('chunk_tags'                  , 'chunk-tags.txt'),
+
+        # SRL
+        ('network_srl'                 , 'srl-network.npz'),
+        ('network_srl_boundary'        , 'srl-id-network.npz'),
+        ('network_srl_classify'        , 'srl-class-network.npz'),
+        ('network_srl_predicates'      , 'srl-class-predicates.npz'),
+        ('srl_iob_tag_dict'            , 'srl-tags.txt'),
+        ('srl_iob_tags'                , 'srl-tags.txt'),
+        ('srl_tags'                    , 'srl-tags.txt'),
+        ('srl_classify_tag_dict'       , 'srl-tags.txt'),
+        ('srl_classify_tags'           , 'srl-tags.txt'),
+        ('srl_predicates_tag_dict'     , 'srl-predicates-tags.txt'),
+        ('srl_predicates_tags'         , 'srl-predicates-tags.txt'),
+        ('type_features_boundary'      , 'types-features-id.npy'),
+        ('caps_features_boundary'      , 'caps-features-id.npy'),
+        ('pos_features_boundary'       , 'pos-features-id.npy'),
+        ('chunk_features_boundary'     , 'chunk-features-id.npy'),
+        ('type_features_classify'      , 'types-features-class.npy'),
+        ('caps_features_classify'      , 'caps-features-class.npy'),
+        ('pos_features_classify'       , 'pos-features-class.npy'),
+        ('chunk_features_classify'     , 'chunk-features-class.npy'),
+        ('type_features_1step'         , 'types-features-1step.npy'),
+        ('caps_features_1step'         , 'caps-features-1step.npy'),
+        ('pos_features_1step'          , 'pos-features-1step.npy'),
+        ('chunk_features_1step'        , 'chunk-features-1step.npy'),
+        ('type_features_srl_predicates', 'types-features-preds.npy'),
+        ('caps_features_srl_predicates', 'caps-features-preds.npy'),
+        ('pos_features_srl_predicates' , 'pos-features-preds.npy'),
+        ('metadata_srl'                , 'metadata-srl.pickle'),
+        ('metadata_srl_boundary'       , 'metadata-srl-boundary.pickle'),
+        ('metadata_srl_classify'       , 'metadata-srl-classify.pickle'),
+        ('metadata_srl_predicates'     , 'metadata-srl-predicates.pickle'),
+        ]
+    }
+
+def set_data_dir(directory):
+    """Sets the global data directory containing the data for the models."""
     global data_dir, FILES
     data_dir = directory
-
-    FILES = {
-         # cross-task data
-         'vocabulary': os.path.join(data_dir, 'vocabulary.txt'),
-         'word_dict_dat': os.path.join(data_dir, 'vocabulary.txt'), # deprecated
-         'type_features': os.path.join(data_dir, 'types-features.npy'),
-         'termvectors': os.path.join(data_dir, 'termvectors.txt'),
-         
-         # POS
-         'network_pos': os.path.join(data_dir, 'pos-network.npz'),
-         'pos_tags': os.path.join(data_dir, 'pos-tags.txt'),
-         'pos_tag_dict': os.path.join(data_dir, 'pos-tags.txt'),
-         'suffixes': os.path.join(data_dir, 'suffixes.txt'),
-         'prefixes': os.path.join(data_dir, 'prefixes.txt'),
-         'metadata_pos': os.path.join(data_dir, 'metadata-pos.pickle'),
-         'type_features_pos': os.path.join(data_dir, 'types-features-pos.npy'),
-         'caps_features_pos': os.path.join(data_dir, 'caps-features-pos.npy'),
-         'suffix_features_pos': os.path.join(data_dir, 'suffix-features-pos.npy'),
-         'prefix_features_pos': os.path.join(data_dir, 'prefix-features-pos.npy'),
-         
-         # chunk
-         'chunk_tag_dict': os.path.join(data_dir, 'chunk-tag-dict.pickle'),
-         'chunk_tags': os.path.join(data_dir, 'chunk-tags.txt'),
-    
-         # SRL
-         'network_srl': os.path.join(data_dir, 'srl-network.npz'),
-         'network_srl_boundary': os.path.join(data_dir, 'srl-id-network.npz'),
-         'network_srl_classify': os.path.join(data_dir, 'srl-class-network.npz'),
-         'network_srl_predicates': os.path.join(data_dir, 'srl-class-predicates.npz'),
-         'srl_iob_tag_dict': os.path.join(data_dir, 'srl-tags.txt'),
-         'srl_iob_tags': os.path.join(data_dir, 'srl-tags.txt'),
-         'srl_tags': os.path.join(data_dir, 'srl-tags.txt'),
-         'srl_classify_tag_dict': os.path.join(data_dir, 'srl-tags.txt'),
-         'srl_classify_tags': os.path.join(data_dir, 'srl-tags.txt'),
-         'srl_predicates_tag_dict': os.path.join(data_dir, 'srl-predicates-tags.txt'),
-         'srl_predicates_tags': os.path.join(data_dir, 'srl-predicates-tags.txt'),
-         'type_features_boundary': os.path.join(data_dir, 'types-features-id.npy'),
-         'caps_features_boundary': os.path.join(data_dir, 'caps-features-id.npy'),
-         'pos_features_boundary': os.path.join(data_dir, 'pos-features-id.npy'),
-         'chunk_features_boundary': os.path.join(data_dir, 'chunk-features-id.npy'),
-         'type_features_classify': os.path.join(data_dir, 'types-features-class.npy'),
-         'caps_features_classify': os.path.join(data_dir, 'caps-features-class.npy'),
-         'pos_features_classify': os.path.join(data_dir, 'pos-features-class.npy'),
-         'chunk_features_classify': os.path.join(data_dir, 'chunk-features-class.npy'),
-         'type_features_1step': os.path.join(data_dir, 'types-features-1step.npy'),
-         'caps_features_1step': os.path.join(data_dir, 'caps-features-1step.npy'),
-         'pos_features_1step': os.path.join(data_dir, 'pos-features-1step.npy'),
-         'chunk_features_1step': os.path.join(data_dir, 'chunk-features-1step.npy'),
-         'type_features_srl_predicates': os.path.join(data_dir, 'types-features-preds.npy'),
-         'caps_features_srl_predicates': os.path.join(data_dir, 'caps-features-preds.npy'),
-         'pos_features_srl_predicates': os.path.join(data_dir, 'pos-features-preds.npy'),
-         'metadata_srl': os.path.join(data_dir, 'metadata-srl.pickle'),
-         'metadata_srl_boundary': os.path.join(data_dir, 'metadata-srl-boundary.pickle'),
-         'metadata_srl_classify': os.path.join(data_dir, 'metadata-srl-classify.pickle'),
-         'metadata_srl_predicates': os.path.join(data_dir, 'metadata-srl-predicates.pickle')
-         }
+    FILES = get_config_paths(directory)
 
 
 

--- a/nlpnet/metadata.py
+++ b/nlpnet/metadata.py
@@ -17,9 +17,10 @@ class Metadata(object):
     parameter files.
     """
     
-    def __init__(self, task, use_caps=True, use_suffix=False, use_prefix=False,
+    def __init__(self, task, paths = None, use_caps=True, use_suffix=False, use_prefix=False,
                  use_pos=False, use_chunk=False, use_lemma=False):
         self.task = task
+        self.paths = paths if paths else config.FILES
         self.use_caps = use_caps
         self.use_suffix = use_suffix
         self.use_prefix = use_prefix
@@ -84,25 +85,23 @@ class Metadata(object):
         Save the contents of the metadata to a file. The filename is determined according
         to the task.
         """
-        filename = 'metadata-%s.pickle' % self.task.replace('_', '-')
-        filename = os.path.join(config.data_dir, filename)
-        with open(filename, 'wb') as f:
-            cPickle.dump(self.__dict__, f, 2)
+        save_data = self.__dict__.copy()
+        del(save_data['paths'])
+        with open(self.paths['metadata_%s' % self.task], 'wb') as f:
+            cPickle.dump(save_data, f, 2)
     
     @classmethod
-    def load_from_file(cls, task):
+    def load_from_file(cls, task, paths = None):
         """
         Reads the file containing the metadata for the given task and returns a 
         Metadata object.
         """
         # the actual content of the file is the __dict__ member variable, which contain all
         # the instance's data
-        filename = os.path.join(config.data_dir, 
-                                'metadata-%s.pickle' % task.replace('_', '-'))
-        md = Metadata(None)
-        with open(filename, 'rb') as f:
-            data = cPickle.load(f)
+        md = Metadata(None, paths if paths else config.FILES)
         
+        with open(paths['metadata_%s' % task], 'rb') as f:
+            data = cPickle.load(f)
         md.__dict__.update(data)
         
         return md

--- a/nlpnet/pos/pos_reader.py
+++ b/nlpnet/pos/pos_reader.py
@@ -13,14 +13,17 @@ class POSReader(TaggerReader):
     readable by the neural network for the POS tagging task.
     """
     
-    def __init__(self, sentences=None, filename=None):
+    def __init__(self, md=None, sentences=None, filename=None):
         """
         :param tagged_text: a sequence of tagged sentences. Each sentence must be a 
             sequence of (token, tag) tuples. If None, the sentences are read from the 
             default location.
         """
+        self.md = md
         self.task = 'pos'
         self.rare_tag = None
+                
+        self._set_metadata(md)
                 
         if sentences is not None:
             self.sentences = sentences

--- a/nlpnet/srl/srl_reader.py
+++ b/nlpnet/srl/srl_reader.py
@@ -12,7 +12,6 @@ import os
 import numpy as np
 from itertools import izip
 
-from .. import config
 from .. import attributes
 from .. import utils
 from ..word_dictionary import WordDictionary
@@ -34,7 +33,7 @@ class ConllPos(object):
 
 class SRLReader(reader.TaggerReader):
     
-    def __init__(self, filename=None, only_boundaries=False, 
+    def __init__(self, md=None, filename=None, only_boundaries=False, 
                  only_classify=False, only_predicates=False):
         """
         The reader will read sentences from a given file. This file must
@@ -48,6 +47,7 @@ class SRLReader(reader.TaggerReader):
         :param only_classify: train to classify pre-determined argument
         :param only_predicates: train to identify only predicates
         """
+        
         if only_boundaries:
             self.task = 'srl_boundary'
             self._generate_iobes_dictionary()
@@ -58,7 +58,9 @@ class SRLReader(reader.TaggerReader):
             self._generate_predicate_id_dictionary()
         else:
             self.task = 'srl'
-            
+        
+        self._set_metadata(md)
+        
         self.rare_tag = 'O'
         
         if filename is not None:
@@ -199,7 +201,7 @@ class SRLReader(reader.TaggerReader):
         
         # only SRL as one step uses IOB tags
         iob = self.task == 'srl'
-        if os.path.isfile(config.FILES['srl_tags']):
+        if os.path.isfile(self.md.paths['srl_tags']):
             self.load_tag_dict(iob=iob)
             return
         
@@ -221,7 +223,7 @@ class SRLReader(reader.TaggerReader):
         # create a dictionary now even if uses IOB, in order to save it in 
         # a deterministic order
         self.tag_dict = {tag: code for code, tag in enumerate(tags)}
-        reader.save_tag_dict(config.FILES['srl_tags'], self.tag_dict)
+        reader.save_tag_dict(self.md.paths['srl_tags'], self.tag_dict)
         logger.debug("Saved SRL tag dictionary.")
         if not iob:
             return
@@ -253,7 +255,7 @@ class SRLReader(reader.TaggerReader):
             return
         
         if filename is None:
-            filename = config.FILES['srl_tags']
+            filename = self.md.paths['srl_tags']
         
         if not iob:
             super(SRLReader, self).load_tag_dict(filename)
@@ -320,14 +322,14 @@ class SRLReader(reader.TaggerReader):
                 token.lemma = new_lemma
                 sent[i] = token
 
-    def create_converter(self, metadata):
+    def create_converter(self):
         """
         This function overrides the TextReader's one in order to deal with Token
         objects instead of raw strings.
         """
         self.converter = attributes.TokenConverter()
         
-        if metadata.use_lemma:
+        if self.md.use_lemma:
             # look up word lemmas 
             word_lookup = lambda t: self.word_dict.get(t.lemma)
         else:
@@ -336,12 +338,12 @@ class SRLReader(reader.TaggerReader):
              
         self.converter.add_extractor(word_lookup)
         
-        if metadata.use_caps:
+        if self.md.use_caps:
             caps_lookup = lambda t: attributes.get_capitalization(t.word)
             self.converter.add_extractor(caps_lookup)
         
-        if metadata.use_pos:
-            with open(config.FILES['pos_tag_dict']) as f:
+        if self.md.use_pos:
+            with open(self.md.paths['pos_tag_dict']) as f:
                 pos_dict = cPickle.load(f)
                 
             pos_def_dict = defaultdict(lambda: pos_dict['other'])
@@ -349,8 +351,8 @@ class SRLReader(reader.TaggerReader):
             pos_lookup = lambda t: pos_def_dict[t.pos]
             self.converter.add_extractor(pos_lookup)
         
-        if metadata.use_chunk:
-            with open(config.FILES['chunk_tag_dict']) as f:
+        if self.md.use_chunk:
+            with open(self.md.paths['chunk_tag_dict']) as f:
                 chunk_dict = cPickle.load(f)
             
             chunk_def_dict = defaultdict(lambda: chunk_dict['O'])

--- a/nlpnet/utils.py
+++ b/nlpnet/utils.py
@@ -10,7 +10,6 @@ import nltk
 import numpy as np
 
 from nltk.tokenize.regexp import RegexpTokenizer
-import config
 import attributes
 
 
@@ -198,19 +197,11 @@ def generate_feature_vectors(num_vectors, num_features, min_value=-0.1, max_valu
     return table
 
 
-def count_pos_tags():
-    """Counts and returns how many POS tags there are."""
-    with open(config.FILES['pos_tags'], 'rb') as f:
-        text = f.read()
-    return len(text.split('\n'))
-
-
-def count_chunk_tags():
-    """Counts and returns how many chunk tags there are."""
-    with open(config.FILES['chunk_tags']) as f:
-        text = f.read()
-    return len(text.split('\n'))
-
+def count_lines(filename):
+    """Counts and returns how many non empty lines in a file there are."""
+    with open(filename, 'r') as f:
+        lines = [x for x in list(f) if x.strip()]
+    return len(lines)
 
 def _create_affix_tables(affix, table_list, num_features):
     """
@@ -247,6 +238,7 @@ def create_feature_tables(args, md, text_reader):
     :param text_reader: The TextReader being used.
     :returns: all the feature tables to be used
     """
+    
     logger = logging.getLogger("Logger")
     feature_tables = []
     
@@ -256,7 +248,7 @@ def create_feature_tables(args, md, text_reader):
         types_table = generate_feature_vectors(table_size, args.num_features)
     else:
         logger.info("Loading word type features...")
-        types_table = load_features_from_file(config.FILES[md.type_features])
+        types_table = load_features_from_file(md.paths[md.type_features])
         
         if len(types_table) < len(text_reader.word_dict):
             # the type dictionary provided has more types than
@@ -293,14 +285,14 @@ def create_feature_tables(args, md, text_reader):
     # POS tags
     if md.use_pos:
         logger.info("Generating POS features...")
-        num_pos_tags = count_pos_tags()
+        num_pos_tags = count_lines(md.paths['pos_tags'])
         pos_table = generate_feature_vectors(num_pos_tags, args.pos)
         feature_tables.append(pos_table)
     
     # chunk tags
     if md.use_chunk:
         logger.info("Generating chunk features...")
-        num_chunk_tags = count_chunk_tags()
+        num_chunk_tags = count_lines(md.paths['chunk_tags'])
         chunk_table = generate_feature_vectors(num_chunk_tags, args.chunk)
         feature_tables.append(chunk_table)
     


### PR DESCRIPTION
...multiple models in the same import. Using global paths is still allowed

Paths are now contained in metadata and are stripped when they are saved. Readers and Taggers are now can use paths in md members. The only thing that still looks sketchy, is the Affix class, as it is a singleton container for affixes in the data folder (which may be customized). This may be as well just a member of the Reader class and contained with it.

In the /bin directory:
Only nlpnet-train and nlpnet-tag were checked for correctness. Other scripts may need a review too. Since reader now gets metadata to the constructor, create_converter doesn't require md as a parameter.
