### PR TITLE
ensures correct numpy array type

### DIFF
--- a/bin/nlpnet-load-embeddings.py
+++ b/bin/nlpnet-load-embeddings.py
@@ -111,7 +111,7 @@ def read_polyglot_embeddings(filename):
     # first four words are UNK, <s>, </s> and padding
     # we discard <s> and </s>
     words = data[0]
-    matrix = data[1]
+    matrix = data[1].astype(np.float)
     matrix = np.delete(matrix, [1, 2], 0)
     
     WD = nlpnet.word_dictionary.WordDictionary


### PR DESCRIPTION
i got a type error below, but this fixed it.

I downloaded the english embeddings from the polyglot website, and then ran the following.

Andrews-MacBook-Pro:nlpnet atrask$ python ./bin/nlpnet-load-embeddings.py polyglot polyglot-en.pkl 
Loading data...
Saving nlpnet data...
Andrews-MacBook-Pro:nlpnet atrask$ python ./bin/nlpnet-train.py pos --gold resources/en-ud-train.conllu --dev resources/en-ud-dev.conllu -e 20 -l 0.001 --load-features
Reading training data...
Loading vocabulary
Creating new network...
Loading word type features...
Created new network with the following layer sizes: 320, 100, 17

Reading validation data...
Loading vocabulary
Training for up to 20 epochs
Traceback (most recent call last):
File "./bin/nlpnet-train.py", line 258, in 
train(nn, text_reader, args)
File "./bin/nlpnet-train.py", line 232, in train
args.iterations, intervals, args.accuracy)
File "nlpnet\network.pyx", line 625, in nlpnet.network.Network.train (nlpnet/network.c:9982)
File "nlpnet\network.pyx", line 688, in nlpnet.network.Network._train_epoch (nlpnet/network.c:11032)
File "nlpnet\network.pyx", line 325, in nlpnet.network.Network._tag_sentence (nlpnet/network.c:6221)
File "nlpnet\network.pyx", line 782, in nlpnet.network.Network._backpropagate (nlpnet/network.c:12426)
ValueError: Buffer dtype mismatch, expected 'FLOAT_t' but got 'float'