### PR TITLE
Lazy import numpy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
-import numpy as np
-from setuptools import setup
-from setuptools import Extension
+from setuptools import Extension, setup
+
+
+class get_numpy_include(object):
+    """Returns Numpy's include path with lazy import."""
+
+    def __str__(self):
+        import numpy
+
+        return numpy.get_include()
 
 
 def readme():
@@ -16,7 +23,7 @@ setup(
         Extension(
             "nlpnet.network",
             ["nlpnet/network.c"],
-            include_dirs=['.', np.get_include()]
+            include_dirs=[".", get_numpy_include()],
         )
     ],
     scripts=[


### PR DESCRIPTION
As described in this PR from another package [cvxgrp/CVXcanon#27](https://github.com/cvxgrp/CVXcanon/pull/27), pip would error if numpy wasn't already installed since it is being imported in the `setup.py` file. This PR postpones the numpy import until the actual compiling phase starts, and it allows pip to evaluate `setup.py` and install dependencies first. 

This should also solve the problem describe in #45 .